### PR TITLE
Small performance improvements 

### DIFF
--- a/src/linux/sm64.cpp
+++ b/src/linux/sm64.cpp
@@ -40,7 +40,7 @@ using namespace pancake::expr;
 using rvaddress_t = uintptr_t;
 
 template<typename T = void*>
-static T get_proc_address(void* handle, string name) {
+static T get_proc_address(void* handle, const string& name) {
   static_assert(std::is_pointer<T>::value, "OOOF");
   
   void* fp = dlsym(handle, name.c_str());

--- a/src/windows/sm64.cpp
+++ b/src/windows/sm64.cpp
@@ -40,7 +40,7 @@ using namespace pancake::expr;
 using rvaddress_t = uintptr_t;
 
 template<typename T = void*>
-static T get_proc_address(HMODULE handle, string name) {
+static T get_proc_address(HMODULE handle, const string& name) {
   static_assert(std::is_pointer<T>::value, "OOOF");
   
   FARPROC fp = GetProcAddress(handle, name.c_str());


### PR DESCRIPTION
At the start the 120 star tas took about 11 seconds to run, the first commit just saves some string copies and saved about a second.

The second makes some assumptions that frame apply will always be called with the same game in one run of the program, but if that is true then it saves 4 more seconds. 